### PR TITLE
Support Targeting Exclusions

### DIFF
--- a/lib/src/feature_filters/targeting_filter.dart
+++ b/lib/src/feature_filters/targeting_filter.dart
@@ -31,18 +31,35 @@ class TargetingFilter extends FeatureFilter {
     Map<String, dynamic> parameters,
     String featureKey,
   ) {
-    final audienceUsers = parameters['Audience']['Users'] as List<dynamic>;
+    final audience = parameters['Audience'] as Map<String, dynamic>;
+
+    if (audience['Exclusion'] != null) {
+      final excludedUsers =
+          parameters['Audience']['Exclusion']['Users'] as List<dynamic>;
+
+      if (userIdentifier != null && excludedUsers.contains(userIdentifier)) {
+        return false;
+      }
+
+      final excludedGroups =
+          parameters['Audience']['Exclusion']['Groups'] as List<dynamic>;
+
+      if (groupIdentifier != null && excludedGroups.contains(groupIdentifier)) {
+        return false;
+      }
+    }
+
+    final audienceUsers = audience['Users'] as List<dynamic>;
 
     // When the passed in [userIdentifier] matches, returns true.
     if (userIdentifier != null && audienceUsers.contains(userIdentifier)) {
       return true;
     }
 
-    final audienceGroups = parameters['Audience']['Groups'] as List<dynamic>;
+    final audienceGroups = audience['Groups'] as List<dynamic>;
 
     // Use the default rollout percentage as default.
-    var rolloutPercentage =
-        parameters['Audience']['DefaultRolloutPercentage'] as int;
+    var rolloutPercentage = audience['DefaultRolloutPercentage'] as int;
 
     for (final audienceGroup in audienceGroups) {
       // When the [groupIdentifier] parameter matches, uses the groups percentage.

--- a/lib/src/feature_filters/targeting_filter.dart
+++ b/lib/src/feature_filters/targeting_filter.dart
@@ -34,18 +34,22 @@ class TargetingFilter extends FeatureFilter {
     final audience = parameters['Audience'] as Map<String, dynamic>;
 
     if (audience['Exclusion'] != null) {
-      final excludedUsers =
-          parameters['Audience']['Exclusion']['Users'] as List<dynamic>;
+      final exclusions = audience['Exclusion'] as Map<String, dynamic>;
+      if (exclusions['Users'] != null) {
+        final excludedUsers = exclusions['Users'] as List<dynamic>;
 
-      if (userIdentifier != null && excludedUsers.contains(userIdentifier)) {
-        return false;
+        if (userIdentifier != null && excludedUsers.contains(userIdentifier)) {
+          return false;
+        }
       }
 
-      final excludedGroups =
-          parameters['Audience']['Exclusion']['Groups'] as List<dynamic>;
+      if (exclusions['Groups'] != null) {
+        final excludedGroups = exclusions['Groups'] as List<dynamic>;
 
-      if (groupIdentifier != null && excludedGroups.contains(groupIdentifier)) {
-        return false;
+        if (groupIdentifier != null &&
+            excludedGroups.contains(groupIdentifier)) {
+          return false;
+        }
       }
     }
 

--- a/test/feature_filters/targeting_filter_test.dart
+++ b/test/feature_filters/targeting_filter_test.dart
@@ -15,10 +15,6 @@ void main() {
           'RolloutPercentage': 100,
         }
       ],
-      'Exclusion': {
-        'Users': ['user3'],
-        'Groups': ['group2'],
-      },
       'DefaultRolloutPercentage': 0,
     },
   };
@@ -68,19 +64,28 @@ void main() {
     },
   );
 
-  test('''if user is excluded return false''', () {
-    final filter = TargetingFilter(userIdentifier: 'user3');
+  group('exclusions', () {
+    setUp(() {
+      params['Audience']['Exclusion'] = {
+        'Users': ['user3'],
+        'Groups': ['group2'],
+      };
+    });
 
-    final actual = filter.evaluate(params, '');
+    test('''if user is excluded return false''', () {
+      final filter = TargetingFilter(userIdentifier: 'user3');
 
-    expect(actual, false);
-  });
+      final actual = filter.evaluate(params, '');
 
-  test('''if group is excluded return false''', () {
-    final filter = TargetingFilter(groupIdentifier: 'group2');
+      expect(actual, false);
+    });
 
-    final actual = filter.evaluate(params, '');
+    test('''if group is excluded return false''', () {
+      final filter = TargetingFilter(groupIdentifier: 'group2');
 
-    expect(actual, false);
+      final actual = filter.evaluate(params, '');
+
+      expect(actual, false);
+    });
   });
 }

--- a/test/feature_filters/targeting_filter_test.dart
+++ b/test/feature_filters/targeting_filter_test.dart
@@ -13,8 +13,12 @@ void main() {
         {
           'Name': 'testGroup',
           'RolloutPercentage': 100,
-        },
+        }
       ],
+      'Exclusion': {
+        'Users': ['user3'],
+        'Groups': ['group2'],
+      },
       'DefaultRolloutPercentage': 0,
     },
   };
@@ -63,4 +67,20 @@ void main() {
       expect(actual, false);
     },
   );
+
+  test('''if user is excluded return false''', () {
+    final filter = TargetingFilter(userIdentifier: 'user3');
+
+    final actual = filter.evaluate(params, '');
+
+    expect(actual, false);
+  });
+
+  test('''if group is excluded return false''', () {
+    final filter = TargetingFilter(groupIdentifier: 'group2');
+
+    final actual = filter.evaluate(params, '');
+
+    expect(actual, false);
+  });
 }


### PR DESCRIPTION
This adds support for user and group exclusions in the TargetingFilter.

If the "Exclusions" are null, continue, otherwise check if the user or group is excluded.
Flow here: #13 